### PR TITLE
Fix labels for radio buttons chart configuration

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/analysis/warnings/charts.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/analysis/warnings/charts.jelly
@@ -12,19 +12,19 @@
     </div>
     <div class="mb-3">
       <input class="form-check-input" type="radio" name="chartType" id="severity" checked="true"/>
-      <label class="form-check-label" for="files">
+      <label class="form-check-label" for="severity">
         Issues by Severity
       </label>
     </div>
     <div class="mb-3">
       <input class="form-check-input" type="radio" name="chartType" id="health"/>
-      <label class="form-check-label" for="loc">
+      <label class="form-check-label" for="health">
         Issues and Health
       </label>
     </div>
     <div class="mb-3">
       <input class="form-check-input" type="radio" name="chartType" id="new"/>
-      <label class="form-check-label" for="delta">
+      <label class="form-check-label" for="new">
         New and fixed issues
       </label>
     </div>


### PR DESCRIPTION
Setting the correct "for" attribute enables us to click the text of a radio button instead of the radio button itself.